### PR TITLE
Fix openam-ldap-utils dependency

### DIFF
--- a/openam-tools/pom.xml
+++ b/openam-tools/pom.xml
@@ -78,6 +78,10 @@
             <artifactId>i18n-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.forgerock.openam</groupId>
+            <artifactId>openam-ldap-utils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,11 @@
                 <artifactId>openam-clientsdk</artifactId>
                 <version>${openam.version}</version>
             </dependency>
+			<dependency>
+				<groupId>org.forgerock.openam</groupId>
+				<artifactId>openam-ldap-utils</artifactId>
+				<version>${openam.version}</version>
+			</dependency>
             <dependency>
                 <groupId>org.forgerock.openam</groupId>
                 <artifactId>openam-shared</artifactId>


### PR DESCRIPTION
Fix for runtime dependency on openam-ldap-utils, which was moved into a separate archive in 12.0.4. It used to be included in openam-client-sdk.